### PR TITLE
Add exact iMPS mapping

### DIFF
--- a/mps_to_circuit/imps_to_circuit_exact.py
+++ b/mps_to_circuit/imps_to_circuit_exact.py
@@ -45,7 +45,7 @@ def _imps_to_circuit_exact(
     mps = _pad_tensor(mps)
     d_left, d, d_right = mps.shape
     assert d == 2, "The physical dimension must be equal to two for qubits."
-    assert d_left == d_right
+    assert d_left == d_right, "The left and right virtual dimensions should be the same."
     z = d
 
     # Reshape to vL * p, vR

--- a/mps_to_circuit/imps_to_circuit_exact.py
+++ b/mps_to_circuit/imps_to_circuit_exact.py
@@ -13,7 +13,7 @@
 import numpy as np
 from qiskit import QuantumCircuit
 
-from .utils import _gram_schmidt, _pad_tensor, _env_unitary, _right_env
+from .utils import _env_unitary, _gram_schmidt, _pad_tensor, _right_env
 
 
 def _imps_to_circuit_exact(

--- a/mps_to_circuit/imps_to_circuit_exact.py
+++ b/mps_to_circuit/imps_to_circuit_exact.py
@@ -1,0 +1,82 @@
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Functions to convert generic matrix product states to quantum circuits."""
+
+import numpy as np
+from qiskit import QuantumCircuit
+
+# Natasha's code
+from qsdqc.env_tensor import env_unitary, right_env
+
+from .utils import (
+    _gram_schmidt,
+    _pad_tensor,
+)
+
+
+
+def _imps_to_circuit_exact(A: np.ndarray, *, shape: str = "lpr", n: int) -> QuantumCircuit:
+    """
+    Convert an infinite, translationally-invariant matrix product state to a quantum circuit.
+
+    TODO: Make work for infinite-MPS with unit cell of >1 sites (Do we need this?)
+
+    Args:
+        A: The tensor representing the translationally invariant MPS in left-canonical form.
+
+        shape: The ordering of the dimensions of A. 'left', 'physical', 'right' by default.
+
+        n: The number of physical sites to represent. NOTE: requires n + 2 * ⌈log2(D)⌉ qubits, where
+        D is the bond dimension.
+
+    Returns:
+        A quantum circuit representing n sites of the infinite MPS.
+    """
+    # Sort indices as vL, p, vR and pad virtual dimensions to nearest power of 2.
+    A = np.transpose(A, (shape.find("l"), shape.find("p"), shape.find("r")))
+    A = _pad_tensor(A)
+    vL, p, vR = A.shape
+    assert p == 2
+    assert vL == vR
+    z = p
+
+    # Reshape to vL * p, vR
+    A = A.reshape(vL * p, vR)
+
+    # Create unitary from isometry, indices p * vL, z * vR. Original isometry columns make up the
+    # least-significant bits
+    matrix = np.zeros((A.shape[0], A.shape[0]), dtype=A.dtype)
+    matrix[:, : A.shape[1]] = A
+    # U has shape vL * p, z * vR, required for circuit U
+    U = _gram_schmidt(matrix)
+
+    # Calculate the right-environment tensor, for this U needs to have shape z * vR, p * vL
+    U1 = U.reshape(vL, p, z, vR)
+    U1 = U1.transpose(2, 3, 1, 0)
+    U1 = U1.reshape(z * vR, p * vL)
+
+    V = env_unitary(right_env(U1, d=2, D=vL))
+
+    # Gate sizes
+    U_size = int(np.ceil(np.log2(U.shape[0])))
+    V_size = int(np.ceil(np.log2(V.shape[0])))
+
+    # Number of qubits required in the circuit
+    N = n + V_size
+
+    qc = QuantumCircuit(N)
+
+    # Reverse the order of qubits for consistency with Qiskit's little-endian ordering.
+    qc.unitary(V, qubits=list(reversed(range(N - V_size, N))), label="V")
+    for i in list(reversed(range(n))):
+        qc.unitary(U, qubits=(list(reversed(range(i, i + U_size)))), label="U")
+
+    return qc

--- a/mps_to_circuit/imps_to_circuit_exact.py
+++ b/mps_to_circuit/imps_to_circuit_exact.py
@@ -13,11 +13,21 @@
 import numpy as np
 from qiskit import QuantumCircuit
 
-from .utils import _env_unitary, _gram_schmidt, _pad_tensor, _right_env
+from .utils import (
+    _env_unitary,
+    _env_unitary_cholesky,
+    _gram_schmidt,
+    _pad_tensor,
+    _right_env,
+)
 
 
 def _imps_to_circuit_exact(
-    mps: np.ndarray, *, shape: str = "lpr", num_sites: int
+    mps: np.ndarray,
+    *,
+    shape: str = "lpr",
+    num_sites: int,
+    cholesky: bool = False,
 ) -> QuantumCircuit:
     """
     Convert an infinite, translationally-invariant matrix product state to a quantum circuit.
@@ -28,6 +38,7 @@ def _imps_to_circuit_exact(
     :param shape: The ordering of the dimensions of mps. 'left', 'physical', 'right' by default.
     :param num_sites: The number of physical sites to represent.
         NOTE: requires num_sites + 2 * ⌈log2(D)⌉ qubits, where D is the bond dimension.
+    :param cholesky: Use Cholesky decomposition to create the right environment tensor.
 
     :return: mps quantum circuit representing num_sites sites of the infinite MPS.
     """
@@ -35,7 +46,7 @@ def _imps_to_circuit_exact(
     mps = np.transpose(mps, (shape.find("l"), shape.find("p"), shape.find("r")))
     mps = _pad_tensor(mps)
     d_left, d, d_right = mps.shape
-    assert d == 2
+    assert d == 2, "The physical dimension must be equal to two for qubits."
     assert d_left == d_right
     z = d
 
@@ -55,7 +66,10 @@ def _imps_to_circuit_exact(
     u_right = u_right.transpose(2, 3, 1, 0)
     u_right = u_right.reshape(z * d_right, d * d_left)
 
-    env_unitary = _env_unitary(_right_env(u_right, d=2, d_left=d_left))
+    if cholesky:
+        env_unitary = _env_unitary_cholesky(_right_env(u_right, d=2, d_left=d_left))
+    else:
+        env_unitary = _env_unitary(_right_env(u_right, d=2, d_left=d_left))
 
     # Gate sizes
     u_size = int(np.ceil(np.log2(unitary.shape[0])))

--- a/mps_to_circuit/imps_to_circuit_exact.py
+++ b/mps_to_circuit/imps_to_circuit_exact.py
@@ -45,7 +45,9 @@ def _imps_to_circuit_exact(
     mps = _pad_tensor(mps)
     d_left, d, d_right = mps.shape
     assert d == 2, "The physical dimension must be equal to two for qubits."
-    assert d_left == d_right, "The left and right virtual dimensions should be the same."
+    assert (
+        d_left == d_right
+    ), "The left and right virtual dimensions should be the same."
     z = d
 
     # Reshape to vL * p, vR

--- a/mps_to_circuit/imps_to_circuit_exact.py
+++ b/mps_to_circuit/imps_to_circuit_exact.py
@@ -13,68 +13,66 @@
 import numpy as np
 from qiskit import QuantumCircuit
 
-from .utils import (
-    _gram_schmidt,
-    _pad_tensor,
-    _env_unitary,
-    _right_env
-)
+from .utils import _gram_schmidt, _pad_tensor, _env_unitary, _right_env
 
 
-def _imps_to_circuit_exact(A: np.ndarray, *, shape: str = "lpr", n: int) -> QuantumCircuit:
+def _imps_to_circuit_exact(
+    mps: np.ndarray, *, shape: str = "lpr", num_sites: int
+) -> QuantumCircuit:
     """
     Convert an infinite, translationally-invariant matrix product state to a quantum circuit.
 
     TODO: Make work for infinite-MPS with unit cell of >1 sites (Do we need this?)
 
-    Args:
-        A: The tensor representing the translationally invariant MPS in left-canonical form.
+    :param mps: The tensor representing the translationally invariant MPS in left-canonical form.
+    :param shape: The ordering of the dimensions of mps. 'left', 'physical', 'right' by default.
+    :param num_sites: The number of physical sites to represent.
+        NOTE: requires num_sites + 2 * ⌈log2(D)⌉ qubits, where D is the bond dimension.
 
-        shape: The ordering of the dimensions of A. 'left', 'physical', 'right' by default.
-
-        n: The number of physical sites to represent. NOTE: requires n + 2 * ⌈log2(D)⌉ qubits, where
-        D is the bond dimension.
-
-    Returns:
-        A quantum circuit representing n sites of the infinite MPS.
+    :return: mps quantum circuit representing num_sites sites of the infinite MPS.
     """
     # Sort indices as vL, p, vR and pad virtual dimensions to nearest power of 2.
-    A = np.transpose(A, (shape.find("l"), shape.find("p"), shape.find("r")))
-    A = _pad_tensor(A)
-    vL, p, vR = A.shape
-    assert p == 2
-    assert vL == vR
-    z = p
+    mps = np.transpose(mps, (shape.find("l"), shape.find("p"), shape.find("r")))
+    mps = _pad_tensor(mps)
+    d_left, d, d_right = mps.shape
+    assert d == 2
+    assert d_left == d_right
+    z = d
 
     # Reshape to vL * p, vR
-    A = A.reshape(vL * p, vR)
+    mps = mps.reshape(d_left * d, d_right)
 
     # Create unitary from isometry, indices p * vL, z * vR. Original isometry columns make up the
     # least-significant bits
-    matrix = np.zeros((A.shape[0], A.shape[0]), dtype=A.dtype)
-    matrix[:, : A.shape[1]] = A
-    # U has shape vL * p, z * vR, required for circuit U
-    U = _gram_schmidt(matrix)
+    matrix = np.zeros((mps.shape[0], mps.shape[0]), dtype=mps.dtype)
+    matrix[:, : mps.shape[1]] = mps
 
-    # Calculate the right-environment tensor, for this U needs to have shape z * vR, p * vL
-    U1 = U.reshape(vL, p, z, vR)
+    # unitary has shape vL * p, z * vR, required for circuit unitary
+    unitary = _gram_schmidt(matrix)
+
+    # Calculate the right-environment tensor, for this unitary needs to have shape z * vR, p * vL
+    U1 = unitary.reshape(d_left, d, z, d_right)
     U1 = U1.transpose(2, 3, 1, 0)
-    U1 = U1.reshape(z * vR, p * vL)
+    U1 = U1.reshape(z * d_right, d * d_left)
 
-    V = _env_unitary(_right_env(U1, d=2, D=vL))
+    env_unitary = _env_unitary(_right_env(U1, d=2, D=d_left))
 
     # Gate sizes
-    U_size = int(np.ceil(np.log2(U.shape[0])))
-    V_size = int(np.ceil(np.log2(V.shape[0])))
+    u_size = int(np.ceil(np.log2(unitary.shape[0])))
+    v_size = int(np.ceil(np.log2(env_unitary.shape[0])))
 
     # Number of qubits required in the circuit
-    N = n + V_size
+    num_qubits = num_sites + v_size
 
-    qc = QuantumCircuit(N)
+    qc = QuantumCircuit(num_qubits)
 
     # Reverse the order of qubits for consistency with Qiskit's little-endian ordering.
-    qc.unitary(V, qubits=list(reversed(range(N - V_size, N))), label="V")
-    for i in list(reversed(range(n))):
-        qc.unitary(U, qubits=(list(reversed(range(i, i + U_size)))), label="U")
+    qc.unitary(
+        env_unitary,
+        qubits=list(reversed(range(num_qubits - v_size, num_qubits))),
+        label="V",
+    )
+    for i in list(reversed(range(num_sites))):
+        qc.unitary(unitary, qubits=(list(reversed(range(i, i + u_size)))), label="U")
 
     return qc

--- a/mps_to_circuit/imps_to_circuit_exact.py
+++ b/mps_to_circuit/imps_to_circuit_exact.py
@@ -51,11 +51,11 @@ def _imps_to_circuit_exact(
     unitary = _gram_schmidt(matrix)
 
     # Calculate the right-environment tensor, for this unitary needs to have shape z * vR, p * vL
-    U1 = unitary.reshape(d_left, d, z, d_right)
-    U1 = U1.transpose(2, 3, 1, 0)
-    U1 = U1.reshape(z * d_right, d * d_left)
+    u_right = unitary.reshape(d_left, d, z, d_right)
+    u_right = u_right.transpose(2, 3, 1, 0)
+    u_right = u_right.reshape(z * d_right, d * d_left)
 
-    env_unitary = _env_unitary(_right_env(U1, d=2, D=d_left))
+    env_unitary = _env_unitary(_right_env(u_right, d=2, d_left=d_left))
 
     # Gate sizes
     u_size = int(np.ceil(np.log2(unitary.shape[0])))

--- a/mps_to_circuit/imps_to_circuit_exact.py
+++ b/mps_to_circuit/imps_to_circuit_exact.py
@@ -32,8 +32,6 @@ def _imps_to_circuit_exact(
     """
     Convert an infinite, translationally-invariant matrix product state to a quantum circuit.
 
-    TODO: Make work for infinite-MPS with unit cell of >1 sites (Do we need this?)
-
     :param mps: The tensor representing the translationally invariant MPS in left-canonical form.
     :param shape: The ordering of the dimensions of mps. 'left', 'physical', 'right' by default.
     :param num_sites: The number of physical sites to represent.

--- a/mps_to_circuit/imps_to_circuit_exact.py
+++ b/mps_to_circuit/imps_to_circuit_exact.py
@@ -13,14 +13,12 @@
 import numpy as np
 from qiskit import QuantumCircuit
 
-# Natasha's code
-from qsdqc.env_tensor import env_unitary, right_env
-
 from .utils import (
     _gram_schmidt,
     _pad_tensor,
+    _env_unitary,
+    _right_env
 )
-
 
 
 def _imps_to_circuit_exact(A: np.ndarray, *, shape: str = "lpr", n: int) -> QuantumCircuit:
@@ -63,7 +61,7 @@ def _imps_to_circuit_exact(A: np.ndarray, *, shape: str = "lpr", n: int) -> Quan
     U1 = U1.transpose(2, 3, 1, 0)
     U1 = U1.reshape(z * vR, p * vL)
 
-    V = env_unitary(right_env(U1, d=2, D=vL))
+    V = _env_unitary(_right_env(U1, d=2, D=vL))
 
     # Gate sizes
     U_size = int(np.ceil(np.log2(U.shape[0])))

--- a/mps_to_circuit/mps_to_circuit.py
+++ b/mps_to_circuit/mps_to_circuit.py
@@ -13,6 +13,7 @@
 import numpy as np
 from qiskit import QuantumCircuit
 
+from .imps_to_circuit_exact import _imps_to_circuit_exact
 from .mps_to_circuit_approx import _mps_to_circuit_approx
 from .mps_to_circuit_exact import _mps_to_circuit_exact
 
@@ -38,5 +39,7 @@ def mps_to_circuit(
             return _mps_to_circuit_exact(mps, shape=shape, **kwargs)
         case "approximate":
             return _mps_to_circuit_approx(mps, shape=shape, **kwargs)
+        case "infinite_exact":
+            return _imps_to_circuit_exact(mps, shape=shape, **kwargs)
         case _:
             raise ValueError(f"Invalid method `{method}`")

--- a/mps_to_circuit/mps_to_circuit_exact.py
+++ b/mps_to_circuit/mps_to_circuit_exact.py
@@ -61,6 +61,7 @@ def _mps_to_circuit_exact(
         # Combine the physical index and right-virtual index of the tensor to construct an isometry
         # matrix. Check the isometry has the required properties.
         d_left, d, d_right = padded_tensor.shape
+        assert d == 2, "The physical dimension must be equal to two for qubits."
         isometry = padded_tensor.reshape((d * d_left, d_right))
         assert _has_orthonormal_columns(isometry)
 

--- a/mps_to_circuit/utils/__init__.py
+++ b/mps_to_circuit/utils/__init__.py
@@ -9,6 +9,7 @@
 # that they have been altered from the originals.
 
 
+from .env_tensor import _env_unitary, _right_env
 from .matrix import (
     _gram_schmidt,
     _has_orthonormal_columns,
@@ -18,7 +19,6 @@ from .tensor import (
     _pad_tensor,
     _prepare_mps,
 )
-from .env_tensor import _right_env, _env_unitary
 
 __all__ = [
     "_gram_schmidt",

--- a/mps_to_circuit/utils/__init__.py
+++ b/mps_to_circuit/utils/__init__.py
@@ -18,6 +18,10 @@ from .tensor import (
     _pad_tensor,
     _prepare_mps,
 )
+from .env_tensor import (
+    _right_env,
+    _env_unitary
+)
 
 __all__ = [
     "_gram_schmidt",
@@ -25,4 +29,6 @@ __all__ = [
     "_is_unitary",
     "_pad_tensor",
     "_prepare_mps",
+    "_right_env",
+    "_env_unitary"
 ]

--- a/mps_to_circuit/utils/__init__.py
+++ b/mps_to_circuit/utils/__init__.py
@@ -9,7 +9,7 @@
 # that they have been altered from the originals.
 
 
-from .env_tensor import _env_unitary, _right_env
+from .env_tensor import _env_unitary, _env_unitary_cholesky, _right_env
 from .matrix import (
     _gram_schmidt,
     _has_orthonormal_columns,
@@ -28,4 +28,5 @@ __all__ = [
     "_prepare_mps",
     "_right_env",
     "_env_unitary",
+    "_env_unitary_cholesky",
 ]

--- a/mps_to_circuit/utils/__init__.py
+++ b/mps_to_circuit/utils/__init__.py
@@ -18,10 +18,7 @@ from .tensor import (
     _pad_tensor,
     _prepare_mps,
 )
-from .env_tensor import (
-    _right_env,
-    _env_unitary
-)
+from .env_tensor import _right_env, _env_unitary
 
 __all__ = [
     "_gram_schmidt",
@@ -30,5 +27,5 @@ __all__ = [
     "_pad_tensor",
     "_prepare_mps",
     "_right_env",
-    "_env_unitary"
+    "_env_unitary",
 ]

--- a/mps_to_circuit/utils/env_tensor.py
+++ b/mps_to_circuit/utils/env_tensor.py
@@ -9,7 +9,6 @@
 # that they have been altered from the originals.
 
 import numpy as np
-from ncon import ncon
 from scipy.sparse.linalg import eigs
 
 
@@ -32,10 +31,8 @@ def _right_env(u: np.ndarray, d: int, D: int, tolerance: float = 1e-08) -> np.nd
     zero[0] = 1
 
     u = u.reshape([d, D, d, D])
-    transfer = ncon(
-        [zero, u, np.conj(u), zero], ([1], [1, -3, 2, -1], [3, -4, 2, -2], [3])
-    )
-    assert np.allclose(np.eye(D), ncon(transfer, [1, 1, -1, -2]), atol=tolerance)
+    transfer = np.einsum("i,ijkl,mnko,m->lojn", zero, u, np.conj(u), zero)
+    assert np.allclose(np.eye(D), np.einsum("iijk->jk", transfer), atol=tolerance)
     trans_matrix = transfer.reshape(D * D, D * D)
 
     _, left_env = eigs(trans_matrix.T, k=1, which="LM")

--- a/mps_to_circuit/utils/env_tensor.py
+++ b/mps_to_circuit/utils/env_tensor.py
@@ -12,6 +12,7 @@ import numpy as np
 from ncon import ncon
 from scipy.sparse.linalg import eigs
 
+
 def _right_env(u: np.ndarray, d: int, D: int, tolerance: float = 1e-08) -> np.ndarray:
     """
     Calculates the right environment of a given translationally invariant MPS.
@@ -31,7 +32,9 @@ def _right_env(u: np.ndarray, d: int, D: int, tolerance: float = 1e-08) -> np.nd
     zero[0] = 1
 
     u = u.reshape([d, D, d, D])
-    transfer = ncon([zero, u, np.conj(u), zero], ([1], [1, -3, 2, -1], [3, -4, 2, -2], [3]))
+    transfer = ncon(
+        [zero, u, np.conj(u), zero], ([1], [1, -3, 2, -1], [3, -4, 2, -2], [3])
+    )
     assert np.allclose(np.eye(D), ncon(transfer, [1, 1, -1, -2]), atol=tolerance)
     trans_matrix = transfer.reshape(D * D, D * D)
 

--- a/mps_to_circuit/utils/env_tensor.py
+++ b/mps_to_circuit/utils/env_tensor.py
@@ -1,0 +1,73 @@
+import numpy as np
+from ncon import ncon
+from scipy.sparse.linalg import eigs
+
+def _right_env(u: np.ndarray, d: int, D: int, tolerance: float = 1e-08) -> np.ndarray:
+    """
+    Calculates the right environment of a given translationally invariant MPS.
+    Assumes u indices are (zero * vR, p * vL)
+
+    Args:
+        u: A unitary representing the translationally invariant MPS site.
+
+        d: The physical dimension of the MPS site.
+
+        D: The bond dimension of the MPS site.
+
+    Returns:
+        A matrix representing the normalised right environment.
+    """
+    zero = np.zeros(d)
+    zero[0] = 1
+
+    u = u.reshape([d, D, d, D])
+    transfer = ncon([zero, u, np.conj(u), zero], ([1], [1, -3, 2, -1], [3, -4, 2, -2], [3]))
+    assert np.allclose(np.eye(D), ncon(transfer, [1, 1, -1, -2]), atol=tolerance)
+    trans_matrix = transfer.reshape(D * D, D * D)
+
+    _, left_env = eigs(trans_matrix.T, k=1, which="LM")
+    left_env = left_env.reshape(D, D)
+    assert np.allclose(np.eye(D), left_env / np.trace(left_env) * D, atol=tolerance)
+
+    _, right_env = eigs(trans_matrix, k=1, which="LM")
+    right_env = right_env.reshape(D, D)
+
+    norm = np.trace(right_env)
+    return right_env / norm
+
+
+def _env_unitary(right_env: np.ndarray) -> np.ndarray:
+    """
+    Convert full right environment R into single unitary form V.
+
+    Args:
+        right_env: A 2D NumPy array representing the right environment.
+
+    Returns:
+        A unitary matrix representing the single environment tensor V.
+    """
+    u, s, _ = np.linalg.svd(right_env, hermitian=True)
+    s_sqrt = np.sqrt(np.diag(s))
+    v = u @ s_sqrt
+    return _vect_to_unitary(v.reshape(v.shape[0] * v.shape[1], 1))
+
+
+def _env_unitary_cholesky(right_env: np.ndarray) -> np.ndarray:
+    """
+    Convert full right environment R into single unitary form V using the Cholesky decomposition.
+
+    Args:
+        right_env: A 2D NumPy array representing the right environment.
+
+    Returns:
+        A unitary matrix representing the single environment tensor V.
+    """
+    L = np.linalg.cholesky(right_env)
+    return _vect_to_unitary(L.reshape(L.shape[0] * L.shape[0], 1))
+
+
+# vect must be 2D array with 1 column
+def _vect_to_unitary(vect: np.ndarray) -> np.ndarray:
+    u, _, _ = np.linalg.svd(vect)
+    assert np.allclose(vect[:, 0], u[:, 0])
+    return u

--- a/mps_to_circuit/utils/env_tensor.py
+++ b/mps_to_circuit/utils/env_tensor.py
@@ -17,6 +17,8 @@ def _right_env(u: np.ndarray, d: int, d_left: int) -> np.ndarray:
     Calculates the right environment of a given translationally invariant MPS.
     Assumes u indices are (zero * vR, p * vL).
 
+    Computes the right environment using the dominant eigenvalue of the transfer matrix.
+
     :param u: A unitary representing the translationally invariant MPS site.
     :param d: The physical dimension of the MPS site.
     :param d_left: The bond dimension of the MPS site.

--- a/mps_to_circuit/utils/env_tensor.py
+++ b/mps_to_circuit/utils/env_tensor.py
@@ -78,7 +78,6 @@ def _env_unitary_cholesky(right_env: np.ndarray) -> np.ndarray:
     return _vector_to_unitary(lower.reshape(lower.shape[0] * lower.shape[0], 1))
 
 
-# vect must be 2D array with 1 column
 def _vector_to_unitary(vector: np.ndarray) -> np.ndarray:
     """
     :param vector: Must be 2D array with 1 column.

--- a/mps_to_circuit/utils/env_tensor.py
+++ b/mps_to_circuit/utils/env_tensor.py
@@ -12,72 +12,79 @@ import numpy as np
 from scipy.sparse.linalg import eigs
 
 
-def _right_env(u: np.ndarray, d: int, D: int, tolerance: float = 1e-08) -> np.ndarray:
+def _right_env(u: np.ndarray, d: int, d_left: int) -> np.ndarray:
     """
     Calculates the right environment of a given translationally invariant MPS.
-    Assumes u indices are (zero * vR, p * vL)
+    Assumes u indices are (zero * vR, p * vL).
 
-    Args:
-        u: A unitary representing the translationally invariant MPS site.
+    :param u: A unitary representing the translationally invariant MPS site.
+    :param d: The physical dimension of the MPS site.
+    :param d_left: The bond dimension of the MPS site.
 
-        d: The physical dimension of the MPS site.
+    :return: A matrix representing the normalized right environment.
+    """
+    transfer_matrix = _construct_transfer_matrix(u, d, d_left)
 
-        D: The bond dimension of the MPS site.
+    _, right_env = eigs(transfer_matrix, k=1, which="LM")
+    right_env = right_env.reshape(d_left, d_left)
 
-    Returns:
-        A matrix representing the normalised right environment.
+    norm = np.trace(right_env)
+    return right_env / norm
+
+
+def _construct_transfer_matrix(u: np.ndarray, d: int, d_left: int) -> np.ndarray:
+    """
+    Constructs the transfer tensor for a given translationally invariant MPS site.
+
+    The transfer tensor encodes the transfer of quantum information through the MPS chain.
+
+    :param u: A unitary representing the translationally invariant MPS site.
+    :param d: The physical dimension of the MPS site.
+    :param d_left: The bond dimension of the MPS site.
+
+    :return: The constructed transfer tensor.
     """
     zero = np.zeros(d)
     zero[0] = 1
 
-    u = u.reshape([d, D, d, D])
+    u = u.reshape([d, d_left, d, d_left])
     transfer = np.einsum("i,ijkl,mnko,m->lojn", zero, u, np.conj(u), zero)
-    assert np.allclose(np.eye(D), np.einsum("iijk->jk", transfer), atol=tolerance)
-    trans_matrix = transfer.reshape(D * D, D * D)
-
-    _, left_env = eigs(trans_matrix.T, k=1, which="LM")
-    left_env = left_env.reshape(D, D)
-    assert np.allclose(np.eye(D), left_env / np.trace(left_env) * D, atol=tolerance)
-
-    _, right_env = eigs(trans_matrix, k=1, which="LM")
-    right_env = right_env.reshape(D, D)
-
-    norm = np.trace(right_env)
-    return right_env / norm
+    return transfer.reshape(d_left * d_left, d_left * d_left)
 
 
 def _env_unitary(right_env: np.ndarray) -> np.ndarray:
     """
     Convert full right environment R into single unitary form V.
 
-    Args:
-        right_env: A 2D NumPy array representing the right environment.
+    :param right_env: A 2D NumPy array representing the right environment.
 
-    Returns:
-        A unitary matrix representing the single environment tensor V.
+    :return: A unitary matrix representing the single environment tensor V.
     """
     u, s, _ = np.linalg.svd(right_env, hermitian=True)
     s_sqrt = np.sqrt(np.diag(s))
     v = u @ s_sqrt
-    return _vect_to_unitary(v.reshape(v.shape[0] * v.shape[1], 1))
+    return _vector_to_unitary(v.reshape(v.shape[0] * v.shape[1], 1))
 
 
 def _env_unitary_cholesky(right_env: np.ndarray) -> np.ndarray:
     """
     Convert full right environment R into single unitary form V using the Cholesky decomposition.
 
-    Args:
-        right_env: A 2D NumPy array representing the right environment.
+    :param right_env: A 2D NumPy array representing the right environment.
 
-    Returns:
-        A unitary matrix representing the single environment tensor V.
+    :return: A unitary matrix representing the single environment tensor V.
     """
-    L = np.linalg.cholesky(right_env)
-    return _vect_to_unitary(L.reshape(L.shape[0] * L.shape[0], 1))
+    lower = np.linalg.cholesky(right_env)
+    return _vector_to_unitary(lower.reshape(lower.shape[0] * lower.shape[0], 1))
 
 
 # vect must be 2D array with 1 column
-def _vect_to_unitary(vect: np.ndarray) -> np.ndarray:
-    u, _, _ = np.linalg.svd(vect)
-    assert np.allclose(vect[:, 0], u[:, 0])
+def _vector_to_unitary(vector: np.ndarray) -> np.ndarray:
+    """
+    :param vector: Must be 2D array with 1 column.
+
+    :return: A unitary matrix representing the input vector.
+    """
+    u, _, _ = np.linalg.svd(vector)
+    assert np.allclose(vector[:, 0], u[:, 0])
     return u

--- a/mps_to_circuit/utils/env_tensor.py
+++ b/mps_to_circuit/utils/env_tensor.py
@@ -1,3 +1,13 @@
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
 import numpy as np
 from ncon import ncon
 from scipy.sparse.linalg import eigs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ description = "Tool to convert a matrix product state to a Qiskit quantum circui
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "ncon>=2.0.0",
+    "ncon>=2.0.0", #TODO Replace
+    "physics-tenpy>=1.0.5", #TODO Replace
     "qiskit>=1.0.0",
     "quimb==1.8.4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,11 @@ description = "Tool to convert a matrix product state to a Qiskit quantum circui
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
+    "ncon>=2.0.0",
     "qiskit>=1.0.0",
+    "quimb==1.8.4",
 ]
 
 [tool.uv]
-dev-dependencies = ["pytest>=8.3.3", "ruff>=0.7.0", "quimb==1.8.4"]
+dev-dependencies = ["pytest>=8.3.3", "ruff>=0.7.0"]
 override-dependencies = ["quimb==1.8.4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = "Tool to convert a matrix product state to a Qiskit quantum circui
 readme = "README.md"
 requires-python = ">=3.10, <3.13"
 dependencies = [
-    "ncon>=2.0.0", #TODO Replace
     "physics-tenpy>=1.0.5", #TODO Replace
     "qiskit>=1.0.0",
     "quimb==1.8.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ description = "Tool to convert a matrix product state to a Qiskit quantum circui
 readme = "README.md"
 requires-python = ">=3.10, <3.13"
 dependencies = [
-    "physics-tenpy>=1.0.5", #TODO Replace
+    "physics-tenpy>=1.0.5",
     "qiskit>=1.0.0",
-    "quimb==1.8.4",
+    "quimb==1.8.4", #TODO Remove dependency
 ]
 
 [tool.setuptools]
@@ -19,7 +19,7 @@ dev-dependencies = [
     "pytest-cov>=6.0.0",
     "ruff>=0.7.0",
 ]
-override-dependencies = ["quimb==1.8.4"]
+override-dependencies = ["quimb==1.8.4"] #TODO Remove dependency
 
 [tool.ruff]
 lint.extend-select = ["I"]

--- a/test/test_mps_to_circuit.py
+++ b/test/test_mps_to_circuit.py
@@ -194,7 +194,7 @@ def test_imps_to_circuit_gives_correct_single_qubit_rdms(chi_max):
             A, method="infinite_exact", shape="lpr", num_sites=num_sites
         )
         sv = Statevector(qc)
-        
+
         # For each physical (non-support) site, calculate its RDM
         for site in range(support, qc.num_qubits - support):
             qubits_to_trace = list(range(qc.num_qubits))

--- a/test/test_mps_to_circuit.py
+++ b/test/test_mps_to_circuit.py
@@ -19,11 +19,28 @@ from qiskit.quantum_info import (
     state_fidelity,
 )
 from quimb.tensor import MatrixProductState, MPS_rand_state
+from tenpy.algorithms import dmrg
+from tenpy.models.tf_ising import TFIChain
+from tenpy.networks.mps import MPS
 
 from mps_to_circuit import mps_to_circuit
 
-# Natasha's code
-from qsdqc.imps_gs import _ground_state_tfi
+
+def _ground_state_tfi(g: float, max_D: int) -> tuple[float, MPS, TFIChain]:
+    model = TFIChain({"L": 2, "J": 1.0, "g": g, "bc_MPS": "infinite", "conserve": None})
+    product_state = ["up"] * model.lat.N_sites
+    psi = MPS.from_product_state(
+        model.lat.mps_sites(), product_state, bc=model.lat.bc_MPS
+    )
+    dmrg_params = {
+        "mixer": True,
+        "trunc_params": {"chi_max": max_D, "svd_min": 1.0e-10},
+        "max_E_err": 1.0e-10,
+        "combine": True,
+    }
+    eng = dmrg.SingleSiteDMRGEngine(psi, model, dmrg_params)
+    E, psi = eng.run()
+    return E, psi, model
 
 
 def _convert_to_little_endian(statevector: np.ndarray) -> np.ndarray:
@@ -155,7 +172,9 @@ def test_imps_to_circuit_produces_circuit_with_correct_number_of_qubits(chi_max)
     psi = _ground_state_tfi(g=1.2, max_D=chi_max)[1]
     A = psi.get_B(0, form="A").itranspose(["vL", "p", "vR"]).to_ndarray()
     for num_sites in range(1, 4):
-        qc = mps_to_circuit(A, "infinite_exact", shape="lpr", num_sites=num_sites)
+        qc = mps_to_circuit(
+            A, method="infinite_exact", shape="lpr", num_sites=num_sites
+        )
         expected_num_qubits = num_sites + 2 * np.ceil(np.log2(chi_max))
         np.testing.assert_equal(qc.num_qubits, expected_num_qubits)
 
@@ -167,7 +186,9 @@ def test_imps_to_circuit_gives_correct_single_qubit_rdms(chi_max):
     mps_rdm = DensityMatrix(psi.get_rho_segment([0]).to_ndarray())
     support = int(np.ceil(np.log2(chi_max)))
     for num_sites in range(1, 4):
-        qc = mps_to_circuit(A, "infinite_exact", shape="lpr", num_sites=num_sites)
+        qc = mps_to_circuit(
+            A, method="infinite_exact", shape="lpr", num_sites=num_sites
+        )
         sv = Statevector(qc)
         # For each physical (non-support) site, calculate its RDM
         for site in range(support, qc.num_qubits - support):

--- a/test/test_mps_to_circuit.py
+++ b/test/test_mps_to_circuit.py
@@ -13,12 +13,17 @@
 import numpy as np
 import pytest
 from qiskit.quantum_info import (
+    DensityMatrix,
     Statevector,
+    partial_trace,
     state_fidelity,
 )
 from quimb.tensor import MatrixProductState, MPS_rand_state
 
 from mps_to_circuit import mps_to_circuit
+
+# Natasha's code
+from qsdqc.imps_gs import _ground_state_tfi
 
 
 def _convert_to_little_endian(statevector: np.ndarray) -> np.ndarray:
@@ -143,3 +148,31 @@ def test_mps_to_circuit_approx_method_is_exact_for_chi_2():
     fidelity = state_fidelity(expected, result)
 
     assert np.isclose(fidelity, 1.0)
+
+
+@pytest.mark.parametrize("chi_max", range(1, 9))
+def test_imps_to_circuit_produces_circuit_with_correct_number_of_qubits(chi_max):
+    psi = _ground_state_tfi(g=1.2, max_D=chi_max)[1]
+    A = psi.get_B(0, form="A").itranspose(["vL", "p", "vR"]).to_ndarray()
+    for num_sites in range(1, 4):
+        qc = mps_to_circuit(A, "infinite_exact", shape="lpr", num_sites=num_sites)
+        expected_num_qubits = num_sites + 2 * np.ceil(np.log2(chi_max))
+        np.testing.assert_equal(qc.num_qubits, expected_num_qubits)
+
+
+@pytest.mark.parametrize("chi_max", range(1, 9))
+def test_imps_to_circuit_gives_correct_single_qubit_rdms(chi_max):
+    psi = _ground_state_tfi(g=1.2, max_D=chi_max)[1]
+    A = psi.get_B(0, form="A").itranspose(["vL", "p", "vR"]).to_ndarray()
+    mps_rdm = DensityMatrix(psi.get_rho_segment([0]).to_ndarray())
+    support = int(np.ceil(np.log2(chi_max)))
+    for num_sites in range(1, 4):
+        qc = mps_to_circuit(A, "infinite_exact", shape="lpr", num_sites=num_sites)
+        sv = Statevector(qc)
+        # For each physical (non-support) site, calculate its RDM
+        for site in range(support, qc.num_qubits - support):
+            qubits_to_trace = list(range(qc.num_qubits))
+            qubits_to_trace.remove(site)
+            circuit_rdm = partial_trace(sv, qubits_to_trace)
+            fidelity = state_fidelity(mps_rdm, circuit_rdm)
+            np.testing.assert_almost_equal(fidelity, 1)

--- a/test/test_mps_to_circuit.py
+++ b/test/test_mps_to_circuit.py
@@ -169,6 +169,7 @@ def test_mps_to_circuit_approx_method_is_exact_for_chi_2():
 
 @pytest.mark.parametrize("chi_max", range(1, 9))
 def test_imps_to_circuit_produces_circuit_with_correct_number_of_qubits(chi_max):
+    """Ensure the quantum circuit has the expected number of qubits."""
     psi = _ground_state_tfi(g=1.2, max_D=chi_max)[1]
     A = psi.get_B(0, form="A").itranspose(["vL", "p", "vR"]).to_ndarray()
     for num_sites in range(1, 4):
@@ -181,6 +182,9 @@ def test_imps_to_circuit_produces_circuit_with_correct_number_of_qubits(chi_max)
 
 @pytest.mark.parametrize("chi_max", range(1, 9))
 def test_imps_to_circuit_gives_correct_single_qubit_rdms(chi_max):
+    """Verify that the reduced density matrices (RDMs) of the physical sites in the quantum circuit
+    match those of the original MPS.
+    """
     psi = _ground_state_tfi(g=1.2, max_D=chi_max)[1]
     A = psi.get_B(0, form="A").itranspose(["vL", "p", "vR"]).to_ndarray()
     mps_rdm = DensityMatrix(psi.get_rho_segment([0]).to_ndarray())
@@ -190,6 +194,7 @@ def test_imps_to_circuit_gives_correct_single_qubit_rdms(chi_max):
             A, method="infinite_exact", shape="lpr", num_sites=num_sites
         )
         sv = Statevector(qc)
+        
         # For each physical (non-support) site, calculate its RDM
         for site in range(support, qc.num_qubits - support):
             qubits_to_trace = list(range(qc.num_qubits))

--- a/test/utils/test_env_tensor.py
+++ b/test/utils/test_env_tensor.py
@@ -1,0 +1,56 @@
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+import numpy as np
+import pytest
+from scipy.sparse.linalg import eigs
+
+from mps_to_circuit.utils.env_tensor import _construct_transfer_matrix
+
+
+def _generate_unitary_matrix(d: int, d_left: int) -> np.ndarray:
+    """
+    Generates a random unitary matrix of appropriate dimensions.
+
+    :param d: Physical dimension.
+    :param d_left: Bond dimension.
+
+    :return: A random unitary matrix of shape (d * d_left, d * d_left).
+    """
+    size = d * d_left
+    matrix = np.random.randn(size, size) + 1j * np.random.randn(size, size)
+    q, _ = np.linalg.qr(matrix)
+    return q
+
+
+@pytest.mark.parametrize("d, d_left", [(2, 2), (2, 4)])
+def test_construct_transfer_matrix(d: int, d_left: int):
+    """
+    :param d: Physical dimension.
+    :param d_left: Bond dimension.
+    """
+    tolerance = 1e-8
+    u = _generate_unitary_matrix(d, d_left)
+
+    transfer_matrix = _construct_transfer_matrix(u, d, d_left)
+
+    transfer = transfer_matrix.reshape(
+        (d_left, d_left, d_left, d_left)
+    )
+    contraction = np.einsum("iijk->jk", transfer)
+    assert np.allclose(
+        contraction, np.eye(d_left), atol=tolerance
+    ), "Transfer tensor contraction not close to identity matrix."
+
+    _, left_env = eigs(transfer_matrix.T, k=1, which="LM")
+    left_env = left_env.reshape(d_left, d_left)
+    assert np.allclose(
+        np.eye(d_left), left_env / np.trace(left_env) * d_left, atol=tolerance
+    )

--- a/test/utils/test_env_tensor.py
+++ b/test/utils/test_env_tensor.py
@@ -41,9 +41,7 @@ def test_construct_transfer_matrix(d: int, d_left: int):
 
     transfer_matrix = _construct_transfer_matrix(u, d, d_left)
 
-    transfer = transfer_matrix.reshape(
-        (d_left, d_left, d_left, d_left)
-    )
+    transfer = transfer_matrix.reshape((d_left, d_left, d_left, d_left))
     contraction = np.einsum("iijk->jk", transfer)
     assert np.allclose(
         contraction, np.eye(d_left), atol=tolerance

--- a/uv.lock
+++ b/uv.lock
@@ -198,7 +198,7 @@ wheels = [
 
 [[package]]
 name = "mps-to-circuit"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "ncon" },

--- a/uv.lock
+++ b/uv.lock
@@ -153,27 +153,43 @@ wheels = [
 
 [[package]]
 name = "mps-to-circuit"
-version = "0.0.0"
+version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "ncon" },
     { name = "qiskit" },
+    { name = "quimb" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
-    { name = "quimb" },
     { name = "ruff" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "qiskit", specifier = ">=1.0.0" }]
+requires-dist = [
+    { name = "ncon", specifier = ">=2.0.0" },
+    { name = "qiskit", specifier = ">=1.0.0" },
+    { name = "quimb", specifier = "==1.8.4" },
+]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.3.3" },
-    { name = "quimb", specifier = "==1.8.4" },
     { name = "ruff", specifier = ">=0.7.0" },
+]
+
+[[package]]
+name = "ncon"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/f5/20e6a201e45dd1b77bc6cb7a1bb46d3bbeb790d63f38d41534d5e686708a/ncon-2.0.0.tar.gz", hash = "sha256:b307e6d8c1d14ddac2510256c2955e5b9d3b6f4916ec8932be1cd11490bfb28a", size = 11199 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/b7/d507c8624babf43dbff7ec9f39042299bcf1173d789127dc495d0e86bd18/ncon-2.0.0-py3-none-any.whl", hash = "sha256:561c39da0bf0fc6c993b22f27593bd592ce2c4f689fb66508cd84d3e46054c95", size = 8642 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -157,6 +157,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "ncon" },
+    { name = "physics-tenpy" },
     { name = "qiskit" },
     { name = "quimb" },
 ]
@@ -170,6 +171,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "ncon", specifier = ">=2.0.0" },
+    { name = "physics-tenpy", specifier = ">=1.0.5" },
     { name = "qiskit", specifier = ">=1.0.0" },
     { name = "quimb", specifier = "==1.8.4" },
 ]
@@ -273,6 +275,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/35/80cf8f6a4f34017a7fe28242dc45161a1baa55c41563c354d8147e8358b2/pbr-6.1.0.tar.gz", hash = "sha256:788183e382e3d1d7707db08978239965e8b9e4e5ed42669bf4758186734d5f24", size = 124032 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1d/44/6a65ecd630393d47ad3e7d5354768cb7f9a10b3a0eb2cd8c6f52b28211ee/pbr-6.1.0-py2.py3-none-any.whl", hash = "sha256:a776ae228892d8013649c0aeccbb3d5f99ee15e005a4cbb7e61d55a067b28a2a", size = 108529 },
+]
+
+[[package]]
+name = "physics-tenpy"
+version = "1.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/91/67cee054c027c3d0705407736ce24aedfe7fb8e8416711fe8cda77cf47db/physics_tenpy-1.0.5.tar.gz", hash = "sha256:5c3df85322154c97bc8d114ccb00a25f2f163d7c91579ec1d3fda4fecbe0e12e", size = 964587 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/ee/4de2c3c4435f6b4be4e07fb7bdf6402e30c2734fdddfb75b4831d7748dc3/physics_tenpy-1.0.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:60e948ad54253aaa0a631405ff939a52d46d376f9d6a15094da6e701ec521773", size = 1172778 },
+    { url = "https://files.pythonhosted.org/packages/9a/38/aba96ad9d2ae5942ece50e78c1ca2d57708870462bb0e81049fec34aa244/physics_tenpy-1.0.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ba0a6d65083e1e19aa67691b8c0f915add26f2bd28a7859477339a29731ce5f9", size = 1149065 },
+    { url = "https://files.pythonhosted.org/packages/f9/f6/a7e83725a51aa1e505678b06ae422fc9ac0959eceb9c226bd5c6bd0b4843/physics_tenpy-1.0.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7cac9e779902a2edb32d2b87ebb5fcf6fcc772179e34ce3cd200846fa222e90e", size = 2465942 },
+    { url = "https://files.pythonhosted.org/packages/37/bf/953da54c593141b97ba2ca1e02603c2439c979d45705f6bd829270acbad6/physics_tenpy-1.0.5-cp310-cp310-win_amd64.whl", hash = "sha256:024f7e6f00444126efe4718ae3ea1bf63636ce42d9bd651718da4025773590ec", size = 1123881 },
+    { url = "https://files.pythonhosted.org/packages/e8/17/2ed37c74af939bf23c319206e30a4f36a669773a12afa0a50156f9960ac4/physics_tenpy-1.0.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e448812e8cd5815bbe50e880e312e046f809656d2b66e6b0ccf9d71485a55b39", size = 1173972 },
+    { url = "https://files.pythonhosted.org/packages/a7/28/06a5b2a2288b398974d77affb481daa6ceca65a4c30b68e0fae48738ba7b/physics_tenpy-1.0.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5802366e1252ab64f78bf1819ca3792ed47c6c15357cf11a7b065849a098d56e", size = 1149267 },
+    { url = "https://files.pythonhosted.org/packages/1a/1d/4364cfd9d09ba144261b5fa60b159c7549940ec2185fe6e3a7bbb58251dc/physics_tenpy-1.0.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2db7d6957d08ff083c84065f65f3927bd97e40df73369c25642c322ad318b765", size = 2569280 },
+    { url = "https://files.pythonhosted.org/packages/18/75/05ac80cea25384516dd857c0777e46c8631879d5296c86996f89a882d584/physics_tenpy-1.0.5-cp311-cp311-win_amd64.whl", hash = "sha256:8ae041645a75261bf194980788cfb2cf6b700784fdb456858f766d59954f9905", size = 1124614 },
+    { url = "https://files.pythonhosted.org/packages/40/6c/439379e7151ee819c5af1c173032733f75a5a68865ed96b9a41ad2abd967/physics_tenpy-1.0.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:dfdad7261f51d1edcc1f59726cedff942966c4cdad31f60343bed6118f442e61", size = 1173666 },
+    { url = "https://files.pythonhosted.org/packages/1a/2e/edaae8fe0940a2a081fd10e3a032409fe9e687070f7068a8f17f5bcf7821/physics_tenpy-1.0.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e1f99c49ad6e6e9dc4d0193aad7faa12130195969e76872c20fcef5c9f99d356", size = 1148726 },
+    { url = "https://files.pythonhosted.org/packages/99/1a/93dc51f179f188872ea05310f7a4383b6f91ef522ba4392130941fb8f904/physics_tenpy-1.0.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:587d47912419b262be79a63efef2c1a100e30e3c4ebbd23f828b57b8c04c1a7a", size = 2529850 },
+    { url = "https://files.pythonhosted.org/packages/63/cd/0f4ff19c07ee903245a0775ad53b7f57c4944bf52c2abbb01322bfbe9fbb/physics_tenpy-1.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:cc6cbc535157207882cc38a24cc8e1cca1eaca88503a4996c497d6cae6e27db3", size = 1117091 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,6 @@ name = "mps-to-circuit"
 version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
-    { name = "ncon" },
     { name = "physics-tenpy" },
     { name = "qiskit" },
     { name = "quimb" },
@@ -216,7 +215,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ncon", specifier = ">=2.0.0" },
     { name = "physics-tenpy", specifier = ">=1.0.5" },
     { name = "qiskit", specifier = ">=1.0.0" },
     { name = "quimb", specifier = "==1.8.4" },
@@ -227,18 +225,6 @@ dev = [
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.7.0" },
-]
-
-[[package]]
-name = "ncon"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/55/f5/20e6a201e45dd1b77bc6cb7a1bb46d3bbeb790d63f38d41534d5e686708a/ncon-2.0.0.tar.gz", hash = "sha256:b307e6d8c1d14ddac2510256c2955e5b9d3b6f4916ec8932be1cd11490bfb28a", size = 11199 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/b7/d507c8624babf43dbff7ec9f39042299bcf1173d789127dc495d0e86bd18/ncon-2.0.0-py3-none-any.whl", hash = "sha256:561c39da0bf0fc6c993b22f27593bd592ce2c4f689fb66508cd84d3e46054c95", size = 8642 },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds functionality to map an infinite MPS to a quantum circuit by constructing the environment tensors and creating the equivalent quantum gates.

This PR introduces a new function `_imps_to_circuit_exact` that converts an infinite, translationally-invariant matrix product state MPS into a quantum circuit. The implementation includes:

* Unitary construction: Constructs unitary matrices representing the MPS sites and the right environment using both singular value decomposition (SVD) and Cholesky decomposition methods.

* Transfer Matrix and Environment: Computes the transfer matrix and extracts the right environment to incorporate the infinite boundary effects into the quantum circuit.

* Circuit Construction: Assembles the quantum circuit by applying the environment unitary followed by the site unitaries, ensuring compatibility with quantum hardware.