### PR TITLE
Fix author names in BibTeX entry.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ If you use `mps-to-circuit` please cite as per the BibTeX below.
 
 ```bibtex
 @software{mpstocircuit2025,
-  author       = {Declan Millar,
-                  GeorgePennington,
-                  Natasha Siow and
-                  Steven Thomson},
+  author       = {D. A. Millar,
+                  G. W. Pennington,
+                  N. T. M. Siow and
+                  S. J. Thomson},
   title        = {qiskit-community/mps-to-circuit},
   month        = feb,
   year         = 2025,

--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ If you use `mps-to-circuit` please cite as per the BibTeX below.
 
 ```bibtex
 @software{mpstocircuit2025,
-  author       = {D. A. Millar,
-                  G. W. Pennington,
-                  N. T. M. Siow and
-                  S. J. Thomson},
+  author       = {Millar, D. A. and
+                  Pennington, G. W. and
+                  Siow, N. T. M. and
+                  Thomson, S. J. },
   title        = {qiskit-community/mps-to-circuit},
   month        = feb,
   year         = 2025,


### PR DESCRIPTION
The author names in the BibTeX entry don't currently have 'and' between each name (except at the end of the list) resulting in the names appearing in a jumble of initials when using the current BibTeX entry into a .tex file.