### PR TITLE
Fix: apply inverse gates exactly in approximate MPS-to-circuit method

### DIFF
--- a/mps_to_circuit/mps_to_circuit_approx.py
+++ b/mps_to_circuit/mps_to_circuit_approx.py
@@ -39,7 +39,7 @@ def _mps_to_circuit_approx(
     :param num_layers: The number of layers to add to the circuit.
     :param compress: Set to `True` to compress the MPS after each layer to a maximum bond dimension
         of `chi_max`.
-    :param cutoff: Cutoff threshold for the compression. Defaults to 0.001.
+    :param cutoff: Cutoff threshold used when `compress` is `True`. Defaults to 0.001.
     :param chi_max: See description for compress. `chi_max` will be ignored if compress is `False`.
     :param history: Dictionary to store intermediate data from algorithm.
 
@@ -48,7 +48,6 @@ def _mps_to_circuit_approx(
     """
     # Prepare Quimb MPS in the correct form.
     _mps = _prepare_mps(mps, shape)
-    compressed_mps = _mps.copy(deep=True)
     disentangled_mps = _mps.copy(deep=True)
 
     # Check chi_max.
@@ -88,15 +87,16 @@ def _mps_to_circuit_approx(
         for i, _ in enumerate(unitaries):
             inverse = unitaries[-(i + 1)].conj().T
             if inverse.shape[0] == 4:
+                # Keep the residual update exact.
                 disentangled_mps.gate_split(
-                    inverse, (i - 1, i), inplace=True, cutoff=cutoff
+                    inverse, (i - 1, i), inplace=True, cutoff=0.0
                 )
             else:
                 disentangled_mps.gate(inverse, (i), inplace=True, contract=True)
 
         if compress:
             # Compress |ψ_(k+1)> to have maximum bond dimension chi_max.
-            disentangled_mps.compress(form="left", max_bond=chi_max)
+            disentangled_mps.compress(form="left", max_bond=chi_max, cutoff=cutoff)
 
         layer += 1
 

--- a/test/test_mps_to_circuit.py
+++ b/test/test_mps_to_circuit.py
@@ -107,10 +107,10 @@ def test_mps_to_circuit_approx_method(chi_max):
     """
     Test approximate MPS to quantum circuit conversion function.
     - The circuits should have the correct number of gates
-    - Fidelity should increase as more layers are added
+    - The intermediate circuits should be stored in the history
     """
 
-    mps = MPS_rand_state(L=8, bond_dim=chi_max)
+    mps = MPS_rand_state(L=8, bond_dim=chi_max, seed=chi_max)
     mps.compress()
     mps.normalize()
 
@@ -118,33 +118,17 @@ def test_mps_to_circuit_approx_method(chi_max):
         mps._L // 2
     ), f"chi_max={chi_max} is too large for L={mps._L}."
 
-    expected = Statevector(_mps_to_statevector(mps))
-
     arrays = list(mps.arrays)
 
-    for num_layers in range(1, 6):
-        history = {"circuits": []}
+    num_layers = 5
+    history = {"circuits": []}
+    mps_to_circuit(arrays, method="approximate", num_layers=num_layers, history=history)
 
-        qc = mps_to_circuit(
-            arrays, method="approximate", num_layers=num_layers, history=history
-        )
-
+    for layer, qc in enumerate(history["circuits"], start=1):
         # The circuit after num_layers layers should have num_sites * num_layers gates.
-        assert len(qc.data) == mps._L * num_layers
+        assert len(qc.data) == mps._L * layer
 
-        # The history should store a number of circuits equal to num_layers.
-        assert len(history["circuits"]) == num_layers
-
-        result = Statevector(qc)
-        fidelity = state_fidelity(expected, result)
-        previous_fidelity = 0.0
-
-        # Fidelity after num_layers layers should be greater than fidelity after num_layers-1
-        # layers.
-        if num_layers > 0:
-            assert fidelity > previous_fidelity
-
-        previous_fidelity = fidelity
+    assert len(history["circuits"]) == num_layers
 
 
 def test_mps_to_circuit_approx_method_is_exact_for_chi_2():


### PR DESCRIPTION
### Summary

Closes #6.

The approximate method unintentionally truncated the residual MPS during each inverse-gate application, even when `compress=False`. Additionally, the configured cutoff was not passed to the explicit compression step.

Quimb’s `gate_split` applies a two-site gate and performs an SVD to split the result back into MPS tensors. Passing a nonzero cutoff discards singular values during this operation.

The approximate method passed the compression cutoff to every inverse-gate update, introducing truncation regardless of the `compress` setting. Using `cutoff=0.0` preserves the residual update, while optional compression remains controlled by `compress`, `chi_max`, and `cutoff`.

### Changes

**`mps_to_circuit/mps_to_circuit_approx.py`**

- Apply inverse gates with `gate_split(..., cutoff=0.0)`, preserving the residual without SVD truncation.
- Apply the user-provided `cutoff` only during the explicit compression performed when `compress=True`.
- Clarify the scope of `cutoff` in the docstring.
- Remove unused `compressed_mps`.

**`test/test_mps_to_circuit.py`**

- Make random test inputs deterministic.
- Run the five-layer conversion once and validate each circuit stored in `history`.
- Remove the ineffective monotonic-fidelity check. The previous test reset `previous_fidelity` to zero during every iteration, so it only checked that fidelity was positive. Strict monotonicity is also not guaranteed by the greedy approximation.